### PR TITLE
Define and implement streamable http transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,8 +756,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -767,9 +769,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -943,6 +947,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.3",
+ "tower-service",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -1285,6 +1306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,7 +1488,7 @@ dependencies = [
  "indexmap 2.9.0",
  "ndc-models",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.12.15",
  "semver",
  "serde",
@@ -1671,7 +1698,7 @@ dependencies = [
  "opentelemetry",
  "ordered-float",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -1858,6 +1885,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.28",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.2",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,8 +1961,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1890,7 +1982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1900,6 +2002,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -2031,6 +2142,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -2042,19 +2154,26 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.3",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -2081,13 +2200,16 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures",
+ "http 1.3.1",
  "paste",
  "pin-project-lite",
  "process-wrap",
+ "reqwest 0.12.15",
  "rmcp-macros",
  "schemars 1.0.4",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -2115,6 +2237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,7 +2264,21 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -2177,12 +2319,26 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
 version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2453,6 +2609,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2802,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,8 +2871,18 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls",
+ "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+dependencies = [
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -2740,7 +2934,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -2759,7 +2953,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -3129,6 +3323,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Hasura"]
 ndc-sdk = { git = "https://github.com/hasura/ndc-sdk-rs", rev = "0e40ebfc1bdc2cfb7cdcd089662c5f3b2df3bc3b"}
 
 # MCP client library
-rmcp = { version = "0.6.4", features = ["client", "transport-child-process"] }
+rmcp = { version = "0.6.4", features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Create a `config.json` file in the `configuration` directory with the following 
       "type": "stdio",
       "command": "secure-filesystem-server",
       "args": ["--allowed-paths", "/path/to/allowed/directory"]
+    },
+    "remote_server": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      },
+      "timeout_seconds": 30
     }
   }
 }
@@ -56,7 +64,7 @@ Create a `config.json` file in the `configuration` directory with the following 
 You can configure multiple MCP servers with different transport types:
 
 - **stdio**: For local MCP servers that communicate over standard input/output
-- **http**: For remote MCP servers that communicate over HTTP
+- **http**: For remote MCP servers that communicate over streamable HTTP transport (recommended for HTTP-based servers)
 
 ## Usage
 

--- a/config-http-sample.json
+++ b/config-http-sample.json
@@ -1,0 +1,20 @@
+{
+  "servers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "mcp-filesystem-server",
+      "args": ["/home/rakesh/Downloads"],
+      "env": {
+        "DEBUG": "true"
+      }
+    },
+    "remote_mcp_server": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      },
+      "timeout_seconds": 30
+    }
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct StdioConfig {
     pub env_file: Option<String>,
 }
 
-/// Configuration for an SSE-based MCP server
+/// Configuration for an SSE-based MCP server (DEPRECATED - use HTTP instead)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SseConfig {
     /// URL of the server
@@ -34,6 +34,25 @@ pub struct SseConfig {
     pub headers: HashMap<String, String>,
 }
 
+/// Configuration for a streamable HTTP-based MCP server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamableHttpConfig {
+    /// URL of the server
+    pub url: String,
+
+    /// HTTP headers for the server
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+
+    /// Timeout for HTTP requests in seconds
+    #[serde(default = "default_timeout")]
+    pub timeout_seconds: u64,
+}
+
+fn default_timeout() -> u64 {
+    30
+}
+
 /// Configuration for an MCP server
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -42,6 +61,8 @@ pub enum McpServerConfig {
     Stdio(StdioConfig),
     #[serde(rename = "sse")]
     Sse(SseConfig),
+    #[serde(rename = "http")]
+    Http(StreamableHttpConfig),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -1,0 +1,29 @@
+use anyhow::{Result, anyhow};
+use rmcp::{service::RunningService, RoleClient, ServiceExt, transport::streamable_http_client::{StreamableHttpClientTransport, StreamableHttpClientTransportConfig}};
+use std::time::Duration;
+
+use crate::config::StreamableHttpConfig;
+
+/// Create an MCP client using streamable HTTP transport
+pub async fn create_http_client(config: &StreamableHttpConfig) -> Result<RunningService<RoleClient, ()>> {
+    // Extract Authorization header value from config if present
+    let auth_header = config.headers.get("Authorization");
+    // build the config to use with this transport
+    let mut http_config = StreamableHttpClientTransportConfig::with_uri(config.url.clone());
+    // set auth header if present
+    if let Some(auth_header) = auth_header {
+        http_config = http_config.auth_header(auth_header);
+    }
+    // Create streamable HTTP transport using the reqwest client
+    let transport = StreamableHttpClientTransport::from_config(http_config);
+
+    // Create and initialize the client with timeout
+    let service = tokio::time::timeout(
+        Duration::from_secs(config.timeout_seconds),
+        ().serve(transport)
+    ).await
+    .map_err(|_| anyhow!("Timeout during MCP service initialization"))?
+    .map_err(|e| anyhow!("Failed to initialize MCP service: {}", e))?;
+
+    Ok(service)
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,5 +1,6 @@
 mod stdio;
 mod sse;
+mod http;
 
 use anyhow::Result;
 use rmcp::{service::RunningService, RoleClient};
@@ -13,6 +14,9 @@ pub async fn create_mcp_client(config: &McpServerConfig) -> Result<RunningServic
         },
         McpServerConfig::Sse(sse_config) => {
             sse::create_sse_client(sse_config).await
+        },
+        McpServerConfig::Http(http_config) => {
+            http::create_http_client(http_config).await
         }
     }
 }

--- a/src/transport/sse.rs
+++ b/src/transport/sse.rs
@@ -24,6 +24,6 @@ pub async fn create_sse_client(config: &SseConfig) -> Result<RunningService<Role
         _headers.insert(header_name, header_value);
     }
 
-    // For now, return an error since we need to implement SSE transport properly
-    Err(anyhow!("SSE transport not yet implemented"))
+    // SSE transport is deprecated in favor of streamable HTTP transport
+    Err(anyhow!("SSE transport is deprecated. Please use 'http' transport type instead for streamable HTTP transport."))
 }


### PR DESCRIPTION
This pull request adds support for connecting to remote MCP servers using a streamable HTTP transport, deprecates the SSE transport, and updates documentation and configuration to reflect these changes. The main focus is on enabling the new HTTP transport via the `reqwest` client, providing configuration options for headers and timeouts, and guiding users to prefer this approach over the old SSE method.

**Transport Layer Enhancements**
* Added a new `StreamableHttpConfig` struct and updated the `McpServerConfig` enum to support a new `http` transport type for remote MCP servers, allowing configuration of URL, headers, and timeout. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR37-R55) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR64-R65)
* Implemented the `create_http_client` function in `src/transport/http.rs` to initialize MCP clients using the streamable HTTP transport, including support for custom headers and timeouts.
* Updated the transport module to route HTTP transport requests to the new implementation.
* Added the `transport-streamable-http-client-reqwest` feature to the `rmcp` dependency in `Cargo.toml` to enable HTTP transport support.

**Deprecation and Documentation**
* Marked the SSE transport as deprecated in code and updated the SSE client to return an error directing users to use the HTTP transport instead. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL26-R26) [[2]](diffhunk://#diff-240783bdb5d9de977ed008e6ec87eacf5fa3b4cf83c51e64b0d7a187fb433d92L27-R28)
* Updated the documentation in `README.md` to recommend the HTTP transport for remote MCP servers and clarified transport type descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R58) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R67)
* Added a sample configuration file `config-http-sample.json` demonstrating the new HTTP transport configuration options.