### PR TITLE
Add docker build and push workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,43 @@
+name: Build and Push Multi-arch Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build and push'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hasura/mcp-connector
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+            --push .


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and pushing of multi-architecture Docker images for the project. The workflow is manually triggered and allows specifying the version to build and push.

**CI/CD Automation:**

* Added a `.github/workflows/build-and-push.yaml` workflow that builds and pushes Docker images for both `linux/amd64` and `linux/arm64` architectures to the GitHub Container Registry, with support for specifying the version as an input.