### PR TITLE
Add support for env vars in stdio env and http headers

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,8 +6,7 @@ use rmcp::model::{Resource, Tool};
 use schemars::schema::ObjectValidation;
 use std::collections::{BTreeMap, HashMap};
 
-use crate::config::McpServerName;
-use crate::state::ConnectorState;
+use crate::config::{ConnectorConfig, McpServerName};
 
 /// Check if a tool is read-only based on annotations
 fn is_read_only_tool(tool: &Tool) -> bool {
@@ -251,13 +250,13 @@ fn create_scalar_types() -> BTreeMap<models::ScalarTypeName, models::ScalarType>
 }
 
 /// Generate the NDC schema from the connector state
-pub fn generate_schema(state: &ConnectorState) -> models::SchemaResponse {
+pub fn generate_schema(config: &ConnectorConfig) -> models::SchemaResponse {
     let mut collections = Vec::new();
     let mut functions = Vec::new();
     let mut procedures = Vec::new();
 
     // Process each MCP client
-    for (server_name, client) in &state.clients {
+    for (server_name, client) in &config.servers {
         // Add error handling for empty tools/resources
         if client.tools.is_empty() && client.resources.is_empty() {
             tracing::warn!("MCP server {} has no tools or resources", server_name.0);

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -20,7 +20,7 @@ pub async fn create_http_client(
     let mut http_config = StreamableHttpClientTransportConfig::with_uri(config.url.clone());
     // set auth header if present
     if let Some(auth_header) = auth_header {
-        http_config = http_config.auth_header(auth_header);
+        http_config = http_config.auth_header(auth_header.resolve()?);
     }
     // Create streamable HTTP transport using the reqwest client
     let transport = StreamableHttpClientTransport::from_config(http_config);

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -15,7 +15,7 @@ pub async fn create_stdio_client(config: &StdioConfig) -> Result<RunningService<
 
     // Add environment variables
     for (key, value) in &config.env {
-        cmd.env(key, value);
+        cmd.env(key, value.resolve()?);
     }
 
     // Load environment variables from file if specified


### PR DESCRIPTION
This pull request enhances the configuration system to support environment variable indirection for both server environment variables and HTTP headers. It introduces a new enum to represent literal values or values sourced from environment variables, updates schema generation to work with the new configuration structure, and adds validation to ensure environment variables are resolvable at setup time.

**Configuration enhancements:**

* Added a new `EnvVariableValue` enum to allow environment variables and HTTP headers in `StdioConfig` and `StreamableHttpConfig` to be specified either as a literal string or as a reference to an environment variable using a `{ "fromEnv": "VAR_NAME" }` syntax. (`src/config.rs`) [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR16-R35) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL28-R48) [[3]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL54-R74)
* Updated the logic for spawning stdio clients and creating HTTP clients to resolve these values at runtime, supporting both literal and environment-sourced values. (`src/transport/stdio.rs`, `src/transport/http.rs`) [[1]](diffhunk://#diff-f028faf6540a74220131d2f084c97a42eeadd0e5f16131bd83ab163289f9ca7dL18-R18) [[2]](diffhunk://#diff-e0fbcd779fac85c1f2f7d2cecf93c9df46f55afae58b1a8c585a1e47a32b4abbL23-R23)

**Validation improvements:**

* Added a validation step during connector setup to check that all referenced environment variables are present and resolvable, returning a clear error if any are missing. (`src/connector.rs`) [[1]](diffhunk://#diff-8103782608247dc5bdba81119e068330105b47cd36d07addb304b60283edae35R394-R406) [[2]](diffhunk://#diff-8103782608247dc5bdba81119e068330105b47cd36d07addb304b60283edae35R420-R432)

**Schema and state handling:**

* Updated `generate_schema` and related code to work with the new configuration structure, removing the need for a separate state object and using the config directly. (`src/schema.rs`, `src/connector.rs`) [[1]](diffhunk://#diff-cfb402317f9a1267396cd28c72ab83f4236dca6ebbf2f87ed850f2b82da5862dL254-R259) [[2]](diffhunk://#diff-8103782608247dc5bdba81119e068330105b47cd36d07addb304b60283edae35L120-R125) [[3]](diffhunk://#diff-cfb402317f9a1267396cd28c72ab83f4236dca6ebbf2f87ed850f2b82da5862dL9-R9) [[4]](diffhunk://#diff-8103782608247dc5bdba81119e068330105b47cd36d07addb304b60283edae35L16-R20) [[5]](diffhunk://#diff-8103782608247dc5bdba81119e068330105b47cd36d07addb304b60283edae35R8)