### PR TITLE
Use chef to build docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,17 @@
 # Rust build artifacts
 target/
+**/*.rs.bk
+
+# Git
+.git/
+.gitignore
+
+# Documentation
+*.md
+docs/
+
+# CI/CD
+.github/
 
 # Environment files
 .env
@@ -7,3 +19,21 @@ target/
 
 # Configuration files
 configuration/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test files
+tests/
+test_data/
+
+# Temporary files
+*.tmp
+*.temp

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -36,8 +36,12 @@ jobs:
       - name: Build and push Docker image
         env:
           VERSION: ${{ inputs.version }}
+          # Use single platform for faster dev builds, multi-platform for releases
+          PLATFORMS: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform ${{ env.PLATFORMS }} \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
             --push .


### PR DESCRIPTION
This pull request introduces significant improvements to the Docker build process and development workflow for the Rust-based MCP connector project. The main changes focus on optimizing Docker builds for speed and caching, improving CI/CD flexibility, and cleaning up ignored files for a smoother developer experience.

**Dockerfile and Build Optimization:**

* Refactored the `Dockerfile` to use a multi-stage build with `cargo-chef` for efficient dependency caching, resulting in faster incremental builds and smaller images. This introduces distinct `chef`, `planner`, and `builder` stages to separate dependency resolution from application compilation. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R8) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R58)
* Updated the runtime stage to copy the built binaries from a persistent location in `/app` instead of directly from the target directory, aligning with the new build process.

**CI/CD Pipeline Improvements:**

* Modified the GitHub Actions workflow to dynamically select build platforms: builds on the `main` branch use multi-platform (`linux/amd64,linux/arm64`), while other branches default to `linux/amd64` for faster feedback. Added build cache steps to speed up CI builds.

**Development and Environment Cleanup:**

* Expanded the `.dockerignore` file to exclude a wide range of files and directories not needed in the Docker build context, such as Git metadata, documentation, IDE files, OS-specific files, test files, and temporary files, reducing build context size and improving security.