### PR TITLE
Update read-only tool definitions

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -17,6 +17,11 @@ fn is_read_only_tool(tool: &Tool) -> bool {
         || name.starts_with("list")
         || name.starts_with("find")
         || name.starts_with("search")
+        || tool // Check if the tool has annotations and if the read_only_hint is true
+            .annotations
+            .as_ref()
+            .and_then(|annotations| annotations.read_only_hint)
+            .unwrap_or(false)
 }
 
 fn tool_arguments_schema(


### PR DESCRIPTION
This pull request updates the logic for determining if a tool is read-only in the `is_read_only_tool` function. Now, in addition to checking the tool's name, the function also considers the `read_only_hint` annotation if present.

Enhancement to read-only detection:

* Updated `is_read_only_tool` in `src/schema.rs` to check the tool's `annotations.read_only_hint` field, making the read-only status more accurate and flexible.