### PR TITLE
Extend justfile with docker utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 **/*.rs.bk
 *.pdb
+connector-definition.tgz
 
 # Environment files
 .env

--- a/justfile
+++ b/justfile
@@ -19,3 +19,14 @@ serve:
 # Format the code
 format:
     cargo fmt
+
+# Build Docker image with specified tag
+docker-build TAG:
+    docker build -t ghcr.io/hasura/mcp-connector:{{TAG}} .
+
+# Push Docker image to ghcr.io repository
+docker-push TAG:
+    docker push ghcr.io/hasura/mcp-connector:{{TAG}}
+
+pack-connector:
+    tar -czf connector-definition.tgz -C connector-definition .


### PR DESCRIPTION
This pull request enhances the project's `justfile` by adding new commands to streamline Docker image management and packaging tasks. These additions make it easier to build, push, and package the connector for deployment.

**Docker image management:**

* Added a `docker-build` command to build a Docker image with a specified tag.
* Added a `docker-push` command to push the Docker image to the `ghcr.io` repository.

**Packaging:**

* Added a `pack-connector` command to create a compressed tarball (`connector-definition.tgz`) from the `connector-definition` directory.