### PR TITLE
Fix arguments

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -322,11 +322,17 @@ impl Connector for McpConnector {
                 })
                 .collect::<Vec<_>>();
 
+            let structured_content = result
+                .structured_content
+                .and_then(|content| serde_json::to_string(&content).ok());
+
             // Convert content to a row
             let mut row = IndexMap::new();
             row.insert(
                 "__value".into(),
-                models::RowFieldValue(serde_json::json!({"content": contents})),
+                models::RowFieldValue(serde_json::json!(
+                        {"content": contents, "structured_content": structured_content}
+                )),
             );
             let rowset = models::RowSet {
                 rows: Some(vec![row]),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -289,14 +289,29 @@ fn create_object_types() -> BTreeMap<String, ObjectType> {
 
     // Create ToolOutput type
     let mut tool_fields = BTreeMap::new();
+    // content field
     tool_fields.insert(
         "content".into(),
         ObjectField {
-            description: Some("The output of the tool".to_string()),
+            description: Some("The text output of the tool".to_string()),
             r#type: Type::Array {
                 element_type: Box::new(Type::Named {
                     name: "Content".to_string().into(),
                 }),
+            },
+            arguments: BTreeMap::new(),
+        },
+    );
+
+    // optional structured content field
+    tool_fields.insert(
+        "structured_content".into(),
+        ObjectField {
+            description: Some(
+                "The structured output of the tool. This is a JSON string.".to_string(),
+            ),
+            r#type: Type::Named {
+                name: "String".to_string().into(),
             },
             arguments: BTreeMap::new(),
         },
@@ -328,10 +343,22 @@ fn create_scalar_types() -> BTreeMap<models::ScalarTypeName, models::ScalarType>
     let mut scalar_types = BTreeMap::new();
 
     // Add core scalar types
-    scalar_types.insert("String".to_string().into(), create_scalar_type(models::TypeRepresentation::String));
-    scalar_types.insert("Boolean".to_string().into(), create_scalar_type(models::TypeRepresentation::Boolean));
-    scalar_types.insert("Int".to_string().into(), create_scalar_type(models::TypeRepresentation::Int32));
-    scalar_types.insert("Float".to_string().into(), create_scalar_type(models::TypeRepresentation::Float64));
+    scalar_types.insert(
+        "String".to_string().into(),
+        create_scalar_type(models::TypeRepresentation::String),
+    );
+    scalar_types.insert(
+        "Boolean".to_string().into(),
+        create_scalar_type(models::TypeRepresentation::Boolean),
+    );
+    scalar_types.insert(
+        "Int".to_string().into(),
+        create_scalar_type(models::TypeRepresentation::Int32),
+    );
+    scalar_types.insert(
+        "Float".to_string().into(),
+        create_scalar_type(models::TypeRepresentation::Float64),
+    );
 
     scalar_types
 }
@@ -386,7 +413,8 @@ mod tests {
         // Test string type
         let string_schema = serde_json::from_value(json!({
             "type": "string"
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&string_schema);
         match ndc_type {
             Type::Named { name } => assert_eq!(name.as_str(), "String"),
@@ -396,7 +424,8 @@ mod tests {
         // Test integer type
         let int_schema = serde_json::from_value(json!({
             "type": "integer"
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&int_schema);
         match ndc_type {
             Type::Named { name } => assert_eq!(name.as_str(), "Int"),
@@ -406,7 +435,8 @@ mod tests {
         // Test number type
         let number_schema = serde_json::from_value(json!({
             "type": "number"
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&number_schema);
         match ndc_type {
             Type::Named { name } => assert_eq!(name.as_str(), "Float"),
@@ -416,7 +446,8 @@ mod tests {
         // Test boolean type
         let bool_schema = serde_json::from_value(json!({
             "type": "boolean"
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&bool_schema);
         match ndc_type {
             Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
@@ -432,15 +463,14 @@ mod tests {
             "items": {
                 "type": "string"
             }
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&string_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
-                    _ => panic!("Expected Named element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                _ => panic!("Expected Named element type"),
+            },
             _ => panic!("Expected Array type"),
         }
 
@@ -450,15 +480,14 @@ mod tests {
             "items": {
                 "type": "integer"
             }
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&int_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "Int"),
-                    _ => panic!("Expected Named element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "Int"),
+                _ => panic!("Expected Named element type"),
+            },
             _ => panic!("Expected Array type"),
         }
 
@@ -468,15 +497,14 @@ mod tests {
             "items": {
                 "type": "number"
             }
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&number_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "Float"),
-                    _ => panic!("Expected Named element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "Float"),
+                _ => panic!("Expected Named element type"),
+            },
             _ => panic!("Expected Array type"),
         }
 
@@ -486,30 +514,28 @@ mod tests {
             "items": {
                 "type": "boolean"
             }
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&bool_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
-                    _ => panic!("Expected Named element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
+                _ => panic!("Expected Named element type"),
+            },
             _ => panic!("Expected Array type"),
         }
 
         // Test array without items schema (should default to String array)
         let generic_array_schema = serde_json::from_value(json!({
             "type": "array"
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&generic_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
-                    _ => panic!("Expected Named element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                _ => panic!("Expected Named element type"),
+            },
             _ => panic!("Expected Array type"),
         }
     }
@@ -525,20 +551,19 @@ mod tests {
                     "type": "string"
                 }
             }
-        })).unwrap();
+        }))
+        .unwrap();
         let ndc_type = map_schema_to_ndc_type(&nested_array_schema);
         match ndc_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Array { element_type: inner_element_type } => {
-                        match inner_element_type.as_ref() {
-                            Type::Named { name } => assert_eq!(name.as_str(), "String"),
-                            _ => panic!("Expected Named inner element type"),
-                        }
-                    }
-                    _ => panic!("Expected Array element type"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Array {
+                    element_type: inner_element_type,
+                } => match inner_element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                    _ => panic!("Expected Named inner element type"),
+                },
+                _ => panic!("Expected Array element type"),
+            },
             _ => panic!("Expected Array type"),
         }
     }
@@ -594,75 +619,61 @@ mod tests {
         // Check names argument (required string array)
         let names_arg = arguments.get(&ArgumentName::new("names".into())).unwrap();
         match &names_arg.argument_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
-                    _ => panic!("Expected String element type for names"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                _ => panic!("Expected String element type for names"),
+            },
             _ => panic!("Expected Array type for names"),
         }
 
         // Check scores argument (required number array)
         let scores_arg = arguments.get(&ArgumentName::new("scores".into())).unwrap();
         match &scores_arg.argument_type {
-            Type::Array { element_type } => {
-                match element_type.as_ref() {
-                    Type::Named { name } => assert_eq!(name.as_str(), "Float"),
-                    _ => panic!("Expected Float element type for scores"),
-                }
-            }
+            Type::Array { element_type } => match element_type.as_ref() {
+                Type::Named { name } => assert_eq!(name.as_str(), "Float"),
+                _ => panic!("Expected Float element type for scores"),
+            },
             _ => panic!("Expected Array type for scores"),
         }
 
         // Check flags argument (optional boolean array)
         let flags_arg = arguments.get(&ArgumentName::new("flags".into())).unwrap();
         match &flags_arg.argument_type {
-            Type::Nullable { underlying_type } => {
-                match underlying_type.as_ref() {
-                    Type::Array { element_type } => {
-                        match element_type.as_ref() {
-                            Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
-                            _ => panic!("Expected Boolean element type for flags"),
-                        }
-                    }
-                    _ => panic!("Expected Array underlying type for flags"),
-                }
-            }
+            Type::Nullable { underlying_type } => match underlying_type.as_ref() {
+                Type::Array { element_type } => match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
+                    _ => panic!("Expected Boolean element type for flags"),
+                },
+                _ => panic!("Expected Array underlying type for flags"),
+            },
             _ => panic!("Expected Nullable type for flags"),
         }
 
         // Check ids argument (optional integer array)
         let ids_arg = arguments.get(&ArgumentName::new("ids".into())).unwrap();
         match &ids_arg.argument_type {
-            Type::Nullable { underlying_type } => {
-                match underlying_type.as_ref() {
-                    Type::Array { element_type } => {
-                        match element_type.as_ref() {
-                            Type::Named { name } => assert_eq!(name.as_str(), "Int"),
-                            _ => panic!("Expected Int element type for ids"),
-                        }
-                    }
-                    _ => panic!("Expected Array underlying type for ids"),
-                }
-            }
+            Type::Nullable { underlying_type } => match underlying_type.as_ref() {
+                Type::Array { element_type } => match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Int"),
+                    _ => panic!("Expected Int element type for ids"),
+                },
+                _ => panic!("Expected Array underlying type for ids"),
+            },
             _ => panic!("Expected Nullable type for ids"),
         }
 
         // Check mixed_data argument (optional String array)
-        let mixed_arg = arguments.get(&ArgumentName::new("mixed_data".into())).unwrap();
+        let mixed_arg = arguments
+            .get(&ArgumentName::new("mixed_data".into()))
+            .unwrap();
         match &mixed_arg.argument_type {
-            Type::Nullable { underlying_type } => {
-                match underlying_type.as_ref() {
-                    Type::Array { element_type } => {
-                        match element_type.as_ref() {
-                            Type::Named { name } => assert_eq!(name.as_str(), "String"),
-                            _ => panic!("Expected String element type for mixed_data"),
-                        }
-                    }
-                    _ => panic!("Expected Array underlying type for mixed_data"),
-                }
-            }
+            Type::Nullable { underlying_type } => match underlying_type.as_ref() {
+                Type::Array { element_type } => match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                    _ => panic!("Expected String element type for mixed_data"),
+                },
+                _ => panic!("Expected Array underlying type for mixed_data"),
+            },
             _ => panic!("Expected Nullable type for mixed_data"),
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -310,8 +310,10 @@ fn create_object_types() -> BTreeMap<String, ObjectType> {
             description: Some(
                 "The structured output of the tool. This is a JSON string.".to_string(),
             ),
-            r#type: Type::Named {
-                name: "String".to_string().into(),
+            r#type: Type::Nullable {
+                underlying_type: Box::new(Type::Named {
+                    name: "String".to_string().into(),
+                }),
             },
             arguments: BTreeMap::new(),
         },

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,77 +26,89 @@ fn is_read_only_tool(tool: &Tool) -> bool {
             .unwrap_or(false)
 }
 
+/// Create a named type with the given type name
+fn create_named_type(type_name: &str) -> Type {
+    Type::Named {
+        name: type_name.to_string().into(),
+    }
+}
+
+/// Map a single instance type to NDC type
+fn map_instance_type_to_ndc(instance_type: &InstanceType) -> Type {
+    match instance_type {
+        InstanceType::String => create_named_type("String"),
+        InstanceType::Number => create_named_type("Float"),
+        InstanceType::Integer => create_named_type("Int"),
+        InstanceType::Boolean => create_named_type("Boolean"),
+        _ => create_named_type("String"), // Fallback to String for Object, Null, etc.
+    }
+}
+
+/// Handle array type mapping by examining items schema
+fn map_array_type(schema_obj: &schemars::schema::SchemaObject) -> Type {
+    if let Some(items) = &schema_obj.array {
+        if let Some(items_schema) = &items.items {
+            match items_schema {
+                schemars::schema::SingleOrVec::Single(item_schema) => {
+                    let element_type = map_schema_to_ndc_type(item_schema);
+                    Type::Array {
+                        element_type: Box::new(element_type),
+                    }
+                }
+                schemars::schema::SingleOrVec::Vec(item_schemas) => {
+                    // For multiple item schemas, use first one or fallback to String
+                    if item_schemas.len() == 1 {
+                        let element_type = map_schema_to_ndc_type(&item_schemas[0]);
+                        Type::Array {
+                            element_type: Box::new(element_type),
+                        }
+                    } else {
+                        Type::Array {
+                            element_type: Box::new(create_named_type("String")),
+                        }
+                    }
+                }
+            }
+        } else {
+            // No items schema specified, use String array
+            Type::Array {
+                element_type: Box::new(create_named_type("String")),
+            }
+        }
+    } else {
+        // No array validation specified, use String array
+        Type::Array {
+            element_type: Box::new(create_named_type("String")),
+        }
+    }
+}
+
 /// Map JSON schema type to NDC type
 fn map_schema_to_ndc_type(schema: &Schema) -> Type {
     match schema {
-        Schema::Bool(true) => Type::Named {
-            name: "Json".to_string().into(),
-        },
-        Schema::Bool(false) => Type::Named {
-            name: "String".to_string().into(), // Fallback for false schema
-        },
+        Schema::Bool(_) => create_named_type("String"), // Fallback to String
         Schema::Object(schema_obj) => {
             if let Some(instance_type) = &schema_obj.instance_type {
                 match instance_type {
                     SingleOrVec::Single(instance_type) => match instance_type.as_ref() {
-                        InstanceType::String => Type::Named {
-                            name: "String".to_string().into(),
-                        },
-                        InstanceType::Number => Type::Named {
-                            name: "Float".to_string().into(),
-                        },
-                        InstanceType::Integer => Type::Named {
-                            name: "Int".to_string().into(),
-                        },
-                        InstanceType::Boolean => Type::Named {
-                            name: "Boolean".to_string().into(),
-                        },
-                        InstanceType::Array => {
-                            // For arrays, we'll use Json type for simplicity
-                            // In a more sophisticated implementation, we could parse the items schema
-                            Type::Named {
-                                name: "Json".to_string().into(),
-                            }
-                        }
-                        InstanceType::Object => Type::Named {
-                            name: "Json".to_string().into(),
-                        },
-                        InstanceType::Null => Type::Named {
-                            name: "Json".to_string().into(),
-                        },
+                        InstanceType::Array => map_array_type(schema_obj),
+                        other => map_instance_type_to_ndc(other),
                     },
                     SingleOrVec::Vec(types) => {
-                        // For multiple types, use Json as a fallback
+                        // For multiple types, use first one or fallback to String
                         if types.len() == 1 {
                             match &types[0] {
-                                InstanceType::String => Type::Named {
-                                    name: "String".to_string().into(),
-                                },
-                                InstanceType::Number => Type::Named {
-                                    name: "Float".to_string().into(),
-                                },
-                                InstanceType::Integer => Type::Named {
-                                    name: "Int".to_string().into(),
-                                },
-                                InstanceType::Boolean => Type::Named {
-                                    name: "Boolean".to_string().into(),
-                                },
-                                _ => Type::Named {
-                                    name: "Json".to_string().into(),
-                                },
+                                InstanceType::Array => map_array_type(schema_obj),
+                                other => map_instance_type_to_ndc(other),
                             }
                         } else {
-                            Type::Named {
-                                name: "Json".to_string().into(),
-                            }
+                            create_named_type("String")
                         }
                     }
                 }
             } else {
-                // No instance type specified, default to Json
-                Type::Named {
-                    name: "Json".to_string().into(),
-                }
+                // No instance type specified, default to String
+                create_named_type("String")
             }
         }
     }
@@ -302,63 +314,24 @@ fn create_object_types() -> BTreeMap<String, ObjectType> {
     object_types
 }
 
+/// Create a scalar type with the given representation
+fn create_scalar_type(representation: models::TypeRepresentation) -> models::ScalarType {
+    models::ScalarType {
+        representation,
+        aggregate_functions: BTreeMap::new(),
+        comparison_operators: BTreeMap::new(),
+        extraction_functions: BTreeMap::new(),
+    }
+}
+
 fn create_scalar_types() -> BTreeMap<models::ScalarTypeName, models::ScalarType> {
     let mut scalar_types = BTreeMap::new();
 
-    // Add String scalar type
-    scalar_types.insert(
-        "String".to_string().into(),
-        models::ScalarType {
-            representation: models::TypeRepresentation::String,
-            aggregate_functions: BTreeMap::new(),
-            comparison_operators: BTreeMap::new(),
-            extraction_functions: BTreeMap::new(),
-        },
-    );
-
-    // Add Boolean scalar type
-    scalar_types.insert(
-        "Boolean".to_string().into(),
-        models::ScalarType {
-            representation: models::TypeRepresentation::Boolean,
-            aggregate_functions: BTreeMap::new(),
-            comparison_operators: BTreeMap::new(),
-            extraction_functions: BTreeMap::new(),
-        },
-    );
-
-    // Add Int scalar type
-    scalar_types.insert(
-        "Int".to_string().into(),
-        models::ScalarType {
-            representation: models::TypeRepresentation::Int32,
-            aggregate_functions: BTreeMap::new(),
-            comparison_operators: BTreeMap::new(),
-            extraction_functions: BTreeMap::new(),
-        },
-    );
-
-    // Add Float scalar type
-    scalar_types.insert(
-        "Float".to_string().into(),
-        models::ScalarType {
-            representation: models::TypeRepresentation::Float64,
-            aggregate_functions: BTreeMap::new(),
-            comparison_operators: BTreeMap::new(),
-            extraction_functions: BTreeMap::new(),
-        },
-    );
-
-    // Add Json scalar type
-    scalar_types.insert(
-        "Json".to_string().into(),
-        models::ScalarType {
-            representation: models::TypeRepresentation::JSON,
-            aggregate_functions: BTreeMap::new(),
-            comparison_operators: BTreeMap::new(),
-            extraction_functions: BTreeMap::new(),
-        },
-    );
+    // Add core scalar types
+    scalar_types.insert("String".to_string().into(), create_scalar_type(models::TypeRepresentation::String));
+    scalar_types.insert("Boolean".to_string().into(), create_scalar_type(models::TypeRepresentation::Boolean));
+    scalar_types.insert("Int".to_string().into(), create_scalar_type(models::TypeRepresentation::Int32));
+    scalar_types.insert("Float".to_string().into(), create_scalar_type(models::TypeRepresentation::Float64));
 
     scalar_types
 }
@@ -400,5 +373,297 @@ pub fn generate_schema_from_state(state: &ConnectorState) -> models::SchemaRespo
         scalar_types,
         capabilities: None,
         request_arguments: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_map_schema_to_ndc_type_primitives() {
+        // Test string type
+        let string_schema = serde_json::from_value(json!({
+            "type": "string"
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&string_schema);
+        match ndc_type {
+            Type::Named { name } => assert_eq!(name.as_str(), "String"),
+            _ => panic!("Expected Named type"),
+        }
+
+        // Test integer type
+        let int_schema = serde_json::from_value(json!({
+            "type": "integer"
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&int_schema);
+        match ndc_type {
+            Type::Named { name } => assert_eq!(name.as_str(), "Int"),
+            _ => panic!("Expected Named type"),
+        }
+
+        // Test number type
+        let number_schema = serde_json::from_value(json!({
+            "type": "number"
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&number_schema);
+        match ndc_type {
+            Type::Named { name } => assert_eq!(name.as_str(), "Float"),
+            _ => panic!("Expected Named type"),
+        }
+
+        // Test boolean type
+        let bool_schema = serde_json::from_value(json!({
+            "type": "boolean"
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&bool_schema);
+        match ndc_type {
+            Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
+            _ => panic!("Expected Named type"),
+        }
+    }
+
+    #[test]
+    fn test_map_schema_to_ndc_type_arrays() {
+        // Test array of strings
+        let string_array_schema = serde_json::from_value(json!({
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&string_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                    _ => panic!("Expected Named element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+
+        // Test array of integers
+        let int_array_schema = serde_json::from_value(json!({
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&int_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Int"),
+                    _ => panic!("Expected Named element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+
+        // Test array of numbers
+        let number_array_schema = serde_json::from_value(json!({
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&number_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Float"),
+                    _ => panic!("Expected Named element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+
+        // Test array of booleans
+        let bool_array_schema = serde_json::from_value(json!({
+            "type": "array",
+            "items": {
+                "type": "boolean"
+            }
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&bool_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
+                    _ => panic!("Expected Named element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+
+        // Test array without items schema (should default to String array)
+        let generic_array_schema = serde_json::from_value(json!({
+            "type": "array"
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&generic_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                    _ => panic!("Expected Named element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+    }
+
+    #[test]
+    fn test_map_schema_to_ndc_type_nested_arrays() {
+        // Test array of arrays of strings
+        let nested_array_schema = serde_json::from_value(json!({
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        })).unwrap();
+        let ndc_type = map_schema_to_ndc_type(&nested_array_schema);
+        match ndc_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Array { element_type: inner_element_type } => {
+                        match inner_element_type.as_ref() {
+                            Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                            _ => panic!("Expected Named inner element type"),
+                        }
+                    }
+                    _ => panic!("Expected Array element type"),
+                }
+            }
+            _ => panic!("Expected Array type"),
+        }
+    }
+
+    #[test]
+    fn test_tool_arguments_schema_with_arrays() {
+        // Test a realistic schema with various array types
+        let input_schema = json!({
+            "type": "object",
+            "properties": {
+                "names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Array of names"
+                },
+                "scores": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "description": "Array of scores"
+                },
+                "flags": {
+                    "type": "array",
+                    "items": {
+                        "type": "boolean"
+                    },
+                    "description": "Array of boolean flags"
+                },
+                "ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "description": "Array of integer IDs"
+                },
+                "mixed_data": {
+                    "type": "array",
+                    "description": "Array with no specific item type"
+                }
+            },
+            "required": ["names", "scores"]
+        });
+
+        let input_schema_obj = input_schema.as_object().unwrap().clone();
+        let arguments = tool_arguments_schema(&input_schema_obj);
+
+        // Check that we have the expected arguments
+        assert_eq!(arguments.len(), 5);
+
+        // Check names argument (required string array)
+        let names_arg = arguments.get(&ArgumentName::new("names".into())).unwrap();
+        match &names_arg.argument_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                    _ => panic!("Expected String element type for names"),
+                }
+            }
+            _ => panic!("Expected Array type for names"),
+        }
+
+        // Check scores argument (required number array)
+        let scores_arg = arguments.get(&ArgumentName::new("scores".into())).unwrap();
+        match &scores_arg.argument_type {
+            Type::Array { element_type } => {
+                match element_type.as_ref() {
+                    Type::Named { name } => assert_eq!(name.as_str(), "Float"),
+                    _ => panic!("Expected Float element type for scores"),
+                }
+            }
+            _ => panic!("Expected Array type for scores"),
+        }
+
+        // Check flags argument (optional boolean array)
+        let flags_arg = arguments.get(&ArgumentName::new("flags".into())).unwrap();
+        match &flags_arg.argument_type {
+            Type::Nullable { underlying_type } => {
+                match underlying_type.as_ref() {
+                    Type::Array { element_type } => {
+                        match element_type.as_ref() {
+                            Type::Named { name } => assert_eq!(name.as_str(), "Boolean"),
+                            _ => panic!("Expected Boolean element type for flags"),
+                        }
+                    }
+                    _ => panic!("Expected Array underlying type for flags"),
+                }
+            }
+            _ => panic!("Expected Nullable type for flags"),
+        }
+
+        // Check ids argument (optional integer array)
+        let ids_arg = arguments.get(&ArgumentName::new("ids".into())).unwrap();
+        match &ids_arg.argument_type {
+            Type::Nullable { underlying_type } => {
+                match underlying_type.as_ref() {
+                    Type::Array { element_type } => {
+                        match element_type.as_ref() {
+                            Type::Named { name } => assert_eq!(name.as_str(), "Int"),
+                            _ => panic!("Expected Int element type for ids"),
+                        }
+                    }
+                    _ => panic!("Expected Array underlying type for ids"),
+                }
+            }
+            _ => panic!("Expected Nullable type for ids"),
+        }
+
+        // Check mixed_data argument (optional String array)
+        let mixed_arg = arguments.get(&ArgumentName::new("mixed_data".into())).unwrap();
+        match &mixed_arg.argument_type {
+            Type::Nullable { underlying_type } => {
+                match underlying_type.as_ref() {
+                    Type::Array { element_type } => {
+                        match element_type.as_ref() {
+                            Type::Named { name } => assert_eq!(name.as_str(), "String"),
+                            _ => panic!("Expected String element type for mixed_data"),
+                        }
+                    }
+                    _ => panic!("Expected Array underlying type for mixed_data"),
+                }
+            }
+            _ => panic!("Expected Nullable type for mixed_data"),
+        }
     }
 }


### PR DESCRIPTION
This pull request makes a targeted update to how content is represented in the row structure returned by the `McpConnector`. The change ensures that both the existing `content` and any available `structured_content` are included together in the serialized output, improving the completeness of the data returned.

- Data Structure Enhancement:
  * In the `Connector` implementation for `McpConnector` (`src/connector.rs`), the row now includes both the `content` and a serialized `structured_content` field (if available) in the `__value` map, enabling downstream consumers to access richer structured data.